### PR TITLE
fix: copy correct folder from build output to NGINX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN npm run build
 FROM nginx:1.23.3
 
 # Copy the build output to replace the default nginx contents
-COPY --from=build /usr/local/app/dist/openenzymedb /usr/share/nginx/html/
+COPY --from=build /usr/local/app/dist/openenzymedb/browser /usr/share/nginx/html/
 
 # Copy the nginx config file, which has a try_files rule for SPA routing
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Problem
Docker image fails to run, crashes repeatedly in Kubernetes with the following error message:
```bash
% kubectl get pods -n staging
NAME                                                       READY   STATUS             RESTARTS         AGE
openenzymedb-frontend-staging-758f577b88-w876p             0/1     CrashLoopBackOff   842 (116s ago)   2d23h

% kubectl logs -f openenzymedb-frontend-staging-758f577b88-w876p  -n staging
/entrypoint.sh: line 3: /usr/share/nginx/html/assets/config/envvars.tpl.json: No such file or directory
```

## Approach
* fix: correct the path where the built source is copied into the NGINX runtime container

### Details
Ran the container locally and jumped inside - it looks like the wrong folder may have been copied into `/usr/share/nginx/html` somehow?
```bash
% docker run -it --rm moleculemaker/openenzymedb-frontend bash
Unable to find image 'moleculemaker/openenzymedb-frontend:latest' locally
latest: Pulling from moleculemaker/openenzymedb-frontend
f1f26f570256: Already exists 
84181e80d10e: Already exists 
1ff0f94a8007: Already exists 
d776269cad10: Already exists 
e9427fcfa864: Already exists 
d4ceccbfc269: Already exists 
ddc1582a257b: Pull complete 
3828f5b891d5: Pull complete 
8f3a39867723: Pull complete 
Digest: sha256:a0ddfa201ac0a929c34f40f07d4ac7d0652b08b80ff2b8d939dfdea06506dfcd
Status: Downloaded newer image for moleculemaker/openenzymedb-frontend:latest

root@51906fc79ab1:/# ls -al /usr/share/nginx/html/assets/config
ls: cannot access '/usr/share/nginx/html/assets/config': No such file or directory

root@51906fc79ab1:/# ls -al /usr/share/nginx/html/assets/      
ls: cannot access '/usr/share/nginx/html/assets/': No such file or directory

root@51906fc79ab1:/# ls -al /usr/share/nginx/html/       
total 44
drwxr-xr-x 1 root root  4096 Oct 18 19:15 .
drwxr-xr-x 1 root root  4096 Mar 23  2023 ..
-rw-r--r-- 1 root root 23994 Oct 18 19:15 3rdpartylicenses.txt
-rw-r--r-- 1 root root   497 Dec 13  2022 50x.html
drwxr-xr-x 4 root root  4096 Oct 18 19:15 browser
-rw-r--r-- 1 root root   615 Dec 13  2022 index.html

root@51906fc79ab1:/# ls -al /usr/share/nginx/html/browser
total 1544
drwxr-xr-x 4 root root    4096 Oct 18 19:15 .
drwxr-xr-x 1 root root    4096 Oct 18 19:15 ..
drwxr-xr-x 4 root root    4096 Oct 18 19:15 assets
-rw-r--r-- 1 root root    2238 Oct 18 19:15 favicon.ico
-rw-r--r-- 1 root root   16094 Oct 18 19:15 index.html
-rw-r--r-- 1 root root 1088954 Oct 18 19:15 main-BC6D7TNK.js
drwxr-xr-x 2 root root    4096 Oct 18 19:15 media
-rw-r--r-- 1 root root   34519 Oct 18 19:15 polyfills-FFHMD2TL.js
-rw-r--r-- 1 root root  210623 Oct 18 19:15 scripts-VVOWUI7C.js
-rw-r--r-- 1 root root  201632 Oct 18 19:15 styles-3KK6KHPZ.css
```

## How to Test
1. Test locally to make sure that the files are in the correct location for NGINX to serve them
    * You should see a structure similar to the following:
```bash
% docker run -it --rm moleculemaker/openenzymedb-frontend:pr-1 ls -al /usr/share/nginx/html
total 1548
drwxr-xr-x 1 root root    4096 Oct 21 19:17 .
drwxr-xr-x 1 root root    4096 Mar 23  2023 ..
-rw-r--r-- 1 root root     497 Dec 13  2022 50x.html
drwxr-xr-x 4 root root    4096 Oct 21 19:17 assets
-rw-r--r-- 1 root root    2238 Oct 21 19:17 favicon.ico
-rw-r--r-- 1 root root   16094 Oct 21 19:17 index.html
-rw-r--r-- 1 root root 1088954 Oct 21 19:17 main-BC6D7TNK.js
drwxr-xr-x 2 root root    4096 Oct 21 19:17 media
-rw-r--r-- 1 root root   34519 Oct 21 19:17 polyfills-FFHMD2TL.js
-rw-r--r-- 1 root root  210623 Oct 21 19:17 scripts-VVOWUI7C.js
-rw-r--r-- 1 root root  201632 Oct 21 19:17 styles-3KK6KHPZ.css
```
2. Deploy this image to staging
    * You should see the image no longer crashes on startup