### PR TITLE
fix contact email on about page

### DIFF
--- a/src/app/about-page/about-page.component.html
+++ b/src/app/about-page/about-page.component.html
@@ -397,7 +397,7 @@
                     <h5 class="leading-xl">
                         We welcome your questions, suggestions, feedback, and collaboration! Get in touch with us via
                         email (<a class="text-[#0080FF] underline"
-                            href="mailto:oed-feedback@moleculemaker.org">oed-feedback&#64;moleculemaker.org</a>)
+                            href="mailto:openenzymedb-feedback@moleculemaker.org">openenzymedb-feedback&#64;moleculemaker.org</a>)
                         to share your perspective, or join the Open Enzyme Database community through a data
                         contribution by filling out the form below.
                     </h5>


### PR DESCRIPTION
We had the wrong address on the about page (but the right address in other spots).